### PR TITLE
Add Marstek BLE driver with discovery flow

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,9 @@
   "category": [
     "energy"
   ],
-  "permissions": [],
+  "permissions": [
+    "homey:wireless:ble"
+  ],
   "images": {
     "small": "/assets/images/small.jpg",
     "large": "/assets/images/large.jpg",
@@ -142,6 +144,87 @@
             "en": "Firmware"
           },
           "value": "(unknown)"
+        }
+      ]
+    },
+    {
+      "name": {
+        "en": "Marstek BLE Battery"
+      },
+      "class": "battery",
+      "id": "marstek-ble",
+      "platforms": [
+        "local"
+      ],
+      "connectivity": [
+        "ble"
+      ],
+      "capabilities": [
+        "battery_charging_state",
+        "meter_power",
+        "meter_power.imported",
+        "meter_power.exported",
+        "meter_power.load",
+        "measure_power",
+        "measure_power_ongrid",
+        "measure_power_offgrid",
+        "measure_power_pv",
+        "measure_temperature",
+        "measure_battery"
+      ],
+      "capabilitiesOptions": {
+        "meter_power.imported": {
+          "title": {
+            "en": "Charged (grid)"
+          }
+        },
+        "meter_power.exported": {
+          "title": {
+            "en": "Discharged (grid)"
+          }
+        },
+        "meter_power.load": {
+          "title": {
+            "en": "Load (or off-grid) consumed"
+          }
+        }
+      },
+      "energy": {
+        "homeBattery": true,
+        "meterPowerImportedCapability": "meter_power.imported",
+        "meterPowerExportedCapability": "meter_power.exported"
+      },
+      "images": {
+        "small": "/drivers/marstek-ble/assets/images/small.png",
+        "large": "/drivers/marstek-ble/assets/images/large.png",
+        "xlarge": "/drivers/marstek-ble/assets/images/xlarge.png"
+      },
+      "pair": [
+        {
+          "id": "loading",
+          "template": "loading",
+          "navigation": {
+            "next": "list_devices"
+          },
+          "options": {
+            "title": {
+              "en": "Scanning for Marstek BLE devices"
+            },
+            "body": {
+              "en": "Discovery can take up to 30 seconds. Please wait while Homey scans nearby devices."
+            }
+          }
+        },
+        {
+          "id": "list_devices",
+          "template": "list_devices",
+          "navigation": {
+            "next": "add_devices"
+          }
+        },
+        {
+          "id": "add_devices",
+          "template": "add_devices"
         }
       ]
     }

--- a/drivers/marstek-ble/assets/icon.svg
+++ b/drivers/marstek-ble/assets/icon.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="960" viewBox="0 0 960 960" width="960">
+	<title>Marstek Battery - Outline (Right-Side Perspective)</title>
+	<desc>Stylized outline of a Marstek home battery cabinet with perspective, right side receding.</desc>
+
+	<defs>
+		<style type="text/css">
+			<![CDATA[
+      .outline { fill: none; stroke: #1a1a1a; stroke-width: 40px; stroke-linecap: round; stroke-linejoin: round; }
+      .thin    { fill: none; stroke: #1a1a1a; stroke-width: 20px; stroke-linecap: round; stroke-linejoin: round; }
+      .hair    { fill: none; stroke: #1a1a1a; stroke-width: 10px; stroke-linecap: round; stroke-linejoin: round; }
+    ]]>
+		</style>
+	</defs>
+
+	<polygon points="168.208 81.778 918.492 173.39 918.492 784.135 168.208 875.747" class="outline" style=""></polygon>
+	<polygon points="214.058 137.862 873.306 212.748 871.89 334.898 214.058 305.817" class="thin" style=""></polygon>
+	<line x1="415.437" y1="237.728" x2="722.371" y2="260.631" class="hair" style=""></line>
+	<circle cx="204.488" cy="146.964" r="8.482" class="hair" style="" transform="matrix(1.70519, 0, 0, 1.526865, -21.939233, 3.618294)"></circle>
+	<path d="M 166.299 71.993 L 29.029 88.392 L 29.029 871.116 L 166.299 886.025" class="thin" style=""></path>
+	<polygon points="239.282 36.459 354.146 52.463 351.279 101.691 234.506 88.861" class="outline" style=""></polygon>
+	<polygon points="734.742 97.364 838.964 108.877 832.419 159.429 729.153 143.981" class="outline" style=""></polygon>
+	<circle cx="199.696" cy="584.635" r="20" class="outline" style="" transform="matrix(1.70519, 0, 0, 1.526865, -20.470961, -5.191058)"></circle>
+	<circle cx="494.261" cy="546.107" r="18" class="outline" style="" transform="matrix(1.70519, 0, 0, 1.526865, -20.470961, -5.191058)"></circle>
+	<path d="M 320.049 856.93 L 320.049 887.467" class="thin" style=""></path>
+	<path d="M 822.338 798.103 L 822.338 828.641" class="thin" style=""></path>
+	<circle cx="480.661" cy="169.932" r="8.482" class="hair" style="" transform="matrix(1.70519, 0, 0, 1.526865, -20.470961, 4.352429)"></circle>
+
+</svg>

--- a/drivers/marstek-ble/device.js
+++ b/drivers/marstek-ble/device.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const Homey = require('homey');
+const protocol = require('./lib/protocol');
+
+const SERVICE_UUID = '0000ffe0-0000-1000-8000-00805f9b34fb';
+const CHARACTERISTIC_UUID = '0000ffe1-0000-1000-8000-00805f9b34fb';
+const POLL_INTERVAL_MS = 60 * 1000;
+
+module.exports = class MarstekBleDevice extends Homey.Device {
+
+    pollHandle = null;
+    reconnectHandle = null;
+    peripheral = null;
+    messageSequence = 0;
+
+    async onInit() {
+        if (this.getSetting('debug')) this.log('MarstekBleDevice initialized');
+        await this.resetCapabilities();
+        await this.updateStaticSettings();
+        await this.initializeConnection();
+    }
+
+    async updateStaticSettings() {
+        const updates = {};
+        const storedUuid = this.getStoreValue('peripheralUuid') || (this.getData() ? this.getData().id : null);
+        if (storedUuid && this.getSetting('peripheralUuid') !== storedUuid) updates.peripheralUuid = storedUuid;
+        const storedId = this.getStoreValue('peripheralId');
+        if (storedId && this.getSetting('peripheralId') !== storedId) updates.peripheralId = storedId;
+        const storedMac = this.getSetting('mac');
+        if (!storedMac && this.getStoreValue('mac')) updates.mac = this.getStoreValue('mac');
+        if (Object.keys(updates).length) {
+            try {
+                await this.setSettings(updates);
+            } catch (error) {
+                this.error('Failed to persist static settings', error);
+            }
+        }
+    }
+
+    async initializeConnection() {
+        try {
+            await this.ensurePeripheral();
+            await this.readDeviceInfo();
+            await this.pollStatus();
+            this.startPolling();
+            await this.setAvailable();
+        } catch (error) {
+            this.error('Failed to initialize BLE device', error);
+            await this.setUnavailable(error.message);
+            this.scheduleReconnect();
+        }
+    }
+
+    async resetCapabilities() {
+        const ensureCapability = async capability => {
+            if (!this.hasCapability(capability)) await this.addCapability(capability);
+        };
+        await ensureCapability('meter_power.imported');
+        await ensureCapability('meter_power.exported');
+        await ensureCapability('meter_power.load');
+        await ensureCapability('measure_power_ongrid');
+        await ensureCapability('measure_power_offgrid');
+        await ensureCapability('measure_power_pv');
+
+        await this.setCapabilityValue('battery_charging_state', null);
+        await this.setCapabilityValue('meter_power', null);
+        await this.setCapabilityValue('measure_power', null);
+        await this.setCapabilityValue('measure_temperature', null);
+        await this.setCapabilityValue('measure_battery', null);
+        await this.setCapabilityValue('meter_power.imported', null);
+        await this.setCapabilityValue('meter_power.exported', null);
+        await this.setCapabilityValue('meter_power.load', null);
+        await this.setCapabilityValue('measure_power_ongrid', null);
+        await this.setCapabilityValue('measure_power_offgrid', null);
+        await this.setCapabilityValue('measure_power_pv', null);
+    }
+
+    async ensurePeripheral() {
+        if (this.peripheral && this.peripheral.isConnected) return this.peripheral;
+        const uuid = this.getStoreValue('peripheralUuid') || this.getSetting('peripheralUuid') || (this.getData() ? this.getData().id : null);
+        if (!uuid) {
+            throw new Error('Missing peripheral UUID');
+        }
+        const advertisement = await this.homey.ble.find(uuid);
+        if (!advertisement) {
+            throw new Error('BLE device not found');
+        }
+        this.peripheral = await advertisement.connect();
+        if (this.getSetting('debug')) this.log('Connected to BLE peripheral', uuid);
+        return this.peripheral;
+    }
+
+    async disconnectPeripheral() {
+        if (this.peripheral) {
+            try {
+                await this.peripheral.disconnect();
+            } catch (error) {
+                this.error('Failed to disconnect peripheral', error);
+            }
+            this.peripheral = null;
+        }
+    }
+
+    startPolling() {
+        if (this.pollHandle) return;
+        this.pollHandle = this.homey.setInterval(() => {
+            this.pollStatus().catch(error => this.handlePollError(error));
+        }, POLL_INTERVAL_MS);
+    }
+
+    stopPolling() {
+        if (this.pollHandle) {
+            this.homey.clearInterval(this.pollHandle);
+            this.pollHandle = null;
+        }
+    }
+
+    scheduleReconnect() {
+        if (this.reconnectHandle) return;
+        this.reconnectHandle = this.homey.setTimeout(async () => {
+            this.reconnectHandle = null;
+            await this.initializeConnection();
+        }, 15000);
+    }
+
+    clearReconnect() {
+        if (this.reconnectHandle) {
+            this.homey.clearTimeout(this.reconnectHandle);
+            this.reconnectHandle = null;
+        }
+    }
+
+    async handlePollError(error) {
+        this.error('BLE polling failed', error);
+        await this.setUnavailable(error.message);
+        await this.disconnectPeripheral();
+        this.scheduleReconnect();
+    }
+
+    async pollStatus() {
+        const request = protocol.buildStatusRequest(this.messageSequence++);
+        const response = await this.exchange(request);
+        const status = protocol.parseStatusResponse(response.payload);
+        const result = status && status.result ? status.result : status;
+        if (!result || typeof result !== 'object') {
+            throw new Error('Invalid status payload');
+        }
+        await this.updateCapabilities(result);
+        if (!this.getAvailable()) await this.setAvailable();
+    }
+
+    async readDeviceInfo() {
+        try {
+            const request = protocol.buildDeviceInfoRequest();
+            const response = await this.exchange(request);
+            const info = protocol.parseDeviceInfoResponse(response.payload);
+            const result = info && info.result ? info.result : info;
+            if (!result || typeof result !== 'object') return;
+            const updates = {};
+            if (result.device && this.getSetting('model') !== result.device) updates.model = result.device;
+            if (result.ver && this.getSetting('firmware') !== result.ver) updates.firmware = result.ver;
+            if (result.mac && this.getSetting('mac') !== result.mac) updates.mac = result.mac;
+            if (Object.keys(updates).length) {
+                await this.setSettings(updates);
+            }
+        } catch (error) {
+            this.error('Failed to read device info over BLE', error);
+        }
+    }
+
+    async updateCapabilities(result) {
+        const firmwareSetting = this.getSetting('firmware');
+        const firmware = Number(firmwareSetting) || 0;
+
+        if (!isNaN(result.bat_temp)) {
+            let value = result.bat_temp;
+            if (value > 100) value = value / ((firmware >= 154) ? 1.0 : 10.0);
+            await this.setCapabilityValue('measure_temperature', value);
+        }
+
+        if (!isNaN(result.bat_capacity)) {
+            await this.setCapabilityValue('meter_power', result.bat_capacity / ((firmware >= 154) ? 1000.0 : 100.0));
+        }
+
+        if (!isNaN(result.bat_soc)) {
+            await this.setCapabilityValue('measure_battery', result.bat_soc);
+        }
+
+        if (!isNaN(result.bat_power)) {
+            const state = result.bat_power > 0 ? 'charging' : (result.bat_power < 0 ? 'discharging' : 'idle');
+            await this.setCapabilityValue('battery_charging_state', state);
+            await this.setCapabilityValue('measure_power', result.bat_power / ((firmware >= 154) ? 1.0 : 10.0));
+        }
+
+        if (!isNaN(result.total_grid_input_energy)) {
+            await this.setCapabilityValue('meter_power.imported', result.total_grid_input_energy / ((firmware >= 154) ? 10.0 : 100.0));
+        }
+        if (!isNaN(result.total_grid_output_energy)) {
+            await this.setCapabilityValue('meter_power.exported', result.total_grid_output_energy / ((firmware >= 154) ? 10.0 : 100.0));
+        }
+        if (!isNaN(result.total_load_energy)) {
+            await this.setCapabilityValue('meter_power.load', result.total_load_energy / ((firmware >= 154) ? 10.0 : 100.0));
+        }
+
+        if (!isNaN(result.ongrid_power)) {
+            await this.setCapabilityValue('measure_power_ongrid', result.ongrid_power * -1);
+        }
+        if (!isNaN(result.offgrid_power)) {
+            await this.setCapabilityValue('measure_power_offgrid', result.offgrid_power * -1);
+        }
+        if (!isNaN(result.pv_power)) {
+            await this.setCapabilityValue('measure_power_pv', result.pv_power * -1);
+        }
+    }
+
+    async exchange(requestBuffer) {
+        const peripheral = await this.ensurePeripheral();
+        const serviceUuid = SERVICE_UUID;
+        const characteristicUuid = CHARACTERISTIC_UUID;
+        if (this.getSetting('debug')) this.log('Sending BLE frame', requestBuffer.toString('hex'));
+        await peripheral.write(serviceUuid, characteristicUuid, requestBuffer);
+        const response = await peripheral.read(serviceUuid, characteristicUuid);
+        if (this.getSetting('debug')) this.log('Received BLE frame', response.toString('hex'));
+        return protocol.parseFrame(response);
+    }
+
+    async onDeleted() {
+        this.stopPolling();
+        this.clearReconnect();
+        await this.disconnectPeripheral();
+        if (this.getSetting('debug')) this.log('MarstekBleDevice deleted');
+    }
+
+    async onUninit() {
+        this.stopPolling();
+        this.clearReconnect();
+        await this.disconnectPeripheral();
+        if (this.getSetting('debug')) this.log('MarstekBleDevice uninitialized');
+    }
+};

--- a/drivers/marstek-ble/driver.compose.json
+++ b/drivers/marstek-ble/driver.compose.json
@@ -1,0 +1,69 @@
+{
+  "name": {
+    "en": "Marstek BLE Battery"
+  },
+  "class": "battery",
+  "capabilities": [
+    "battery_charging_state",
+    "meter_power",
+    "meter_power.imported",
+    "meter_power.exported",
+    "meter_power.load",
+    "measure_power",
+    "measure_power_ongrid",
+    "measure_power_offgrid",
+    "measure_power_pv",
+    "measure_temperature",
+    "measure_battery"
+  ],
+  "energy": {
+    "homeBattery": true,
+    "meterPowerImportedCapability": "meter_power.imported",
+    "meterPowerExportedCapability": "meter_power.exported"
+  },
+  "capabilitiesOptions": {
+    "meter_power.imported": {
+      "title": { "en": "Charged (grid)" }
+    },
+    "meter_power.exported": {
+      "title": { "en": "Discharged (grid)" }
+    },
+    "meter_power.load": {
+      "title": { "en": "Load (or off-grid) consumed" }
+    }
+  },
+  "platforms": [
+    "local"
+  ],
+  "connectivity": [
+    "ble"
+  ],
+  "pair": [
+    {
+      "id": "loading",
+      "template": "loading",
+      "navigation": {
+        "next": "list_devices"
+      },
+      "options": {
+        "title": {
+          "en": "Scanning for Marstek BLE devices"
+        },
+        "body": {
+          "en": "Discovery can take up to 30 seconds. Please wait while Homey scans nearby devices."
+        }
+      }
+    },
+    {
+      "id": "list_devices",
+      "template": "list_devices",
+      "navigation": {
+        "next": "add_devices"
+      }
+    },
+    {
+      "id": "add_devices",
+      "template": "add_devices"
+    }
+  ]
+}

--- a/drivers/marstek-ble/driver.js
+++ b/drivers/marstek-ble/driver.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const Homey = require('homey');
+
+module.exports = class MarstekBleDriver extends Homey.Driver {
+
+    async onInit() {
+        this.log('MarstekBleDriver has been initialized');
+    }
+
+    async onPair(session) {
+        this.log('Starting BLE pairing session');
+        let discovered = [];
+
+        const discover = async () => {
+            try {
+                const advertisements = await this.homey.ble.discover();
+                const byUuid = new Map();
+                for (const ad of advertisements) {
+                    if (!ad.localName || !ad.localName.startsWith('MST_')) continue;
+                    const uuid = ad.uuid || ad.id;
+                    if (byUuid.has(uuid)) continue;
+                    byUuid.set(uuid, {
+                        name: ad.localName,
+                        data: { id: uuid },
+                        store: {
+                            peripheralUuid: uuid,
+                            peripheralId: ad.id,
+                            mac: ad.address || '',
+                        },
+                        settings: {
+                            peripheralUuid: uuid,
+                            peripheralId: ad.id,
+                            mac: ad.address || '',
+                            model: '(unknown)',
+                            firmware: '(unknown)'
+                        }
+                    });
+                }
+                discovered = Array.from(byUuid.values());
+                this.log(`Discovered ${discovered.length} BLE device(s)`);
+            } catch (error) {
+                this.error('BLE discovery failed', error);
+                discovered = [];
+            }
+        };
+
+        session.setHandler('showView', async viewId => {
+            if (viewId === 'loading') {
+                await discover();
+                await session.showView('list_devices');
+            }
+        });
+
+        session.setHandler('list_devices', async () => discovered);
+    }
+};

--- a/drivers/marstek-ble/driver.settings.compose.json
+++ b/drivers/marstek-ble/driver.settings.compose.json
@@ -1,0 +1,56 @@
+{
+  "type": "group",
+  "children": [
+    {
+      "id": "debug",
+      "type": "checkbox",
+      "label": {
+        "en": "Enable verbose logging"
+      },
+      "hint": {
+        "en": "Turn on for extra logging while troubleshooting BLE communication."
+      },
+      "value": false
+    },
+    {
+      "id": "peripheralUuid",
+      "type": "label",
+      "label": {
+        "en": "Peripheral UUID"
+      },
+      "value": ""
+    },
+    {
+      "id": "peripheralId",
+      "type": "label",
+      "label": {
+        "en": "Peripheral ID"
+      },
+      "value": ""
+    },
+    {
+      "id": "mac",
+      "type": "label",
+      "label": {
+        "en": "MAC address"
+      },
+      "value": ""
+    },
+    {
+      "id": "model",
+      "type": "label",
+      "label": {
+        "en": "Model"
+      },
+      "value": "(unknown)"
+    },
+    {
+      "id": "firmware",
+      "type": "label",
+      "label": {
+        "en": "Firmware"
+      },
+      "value": "(unknown)"
+    }
+  ]
+}

--- a/drivers/marstek-ble/lib/protocol.js
+++ b/drivers/marstek-ble/lib/protocol.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const HEADER = 0xAA;
+
+const COMMANDS = Object.freeze({
+    DEVICE_INFO: 0x10,
+    STATUS: 0x20,
+});
+
+function calculateChecksum(buffer) {
+    let sum = 0;
+    for (const byte of buffer) {
+        sum = (sum + byte) & 0xFF;
+    }
+    return sum;
+}
+
+function composeCommand(command, payload = Buffer.alloc(0)) {
+    if (!Buffer.isBuffer(payload)) payload = Buffer.from(payload);
+    const length = payload.length + 1; // include command byte
+    const frame = Buffer.alloc(3 + payload.length + 1);
+    frame[0] = HEADER;
+    frame[1] = length;
+    frame[2] = command;
+    if (payload.length) payload.copy(frame, 3);
+    frame[frame.length - 1] = calculateChecksum(frame.slice(1, frame.length - 1));
+    return frame;
+}
+
+function parseFrame(buffer) {
+    if (!Buffer.isBuffer(buffer)) {
+        throw new Error('Response must be a Buffer');
+    }
+    if (buffer.length < 4) {
+        throw new Error('Frame too short');
+    }
+    if (buffer[0] !== HEADER) {
+        throw new Error('Invalid frame header');
+    }
+    const expectedLength = buffer[1];
+    if (expectedLength + 3 !== buffer.length) {
+        throw new Error('Length mismatch in frame');
+    }
+    const checksum = buffer[buffer.length - 1];
+    const calculated = calculateChecksum(buffer.slice(1, buffer.length - 1));
+    if (checksum !== calculated) {
+        throw new Error('Checksum mismatch');
+    }
+    const command = buffer[2];
+    const payload = buffer.slice(3, buffer.length - 1);
+    return { command, payload };
+}
+
+function parseJsonPayload(payload) {
+    const text = payload.toString('utf8').trim();
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start !== -1 && end !== -1 && end >= start) {
+        return JSON.parse(text.slice(start, end + 1));
+    }
+    if (!text) return {};
+    throw new Error('Unexpected payload format');
+}
+
+function buildStatusRequest(sequence = 0) {
+    const payload = Buffer.from([sequence & 0xFF]);
+    return composeCommand(COMMANDS.STATUS, payload);
+}
+
+function parseStatusResponse(payload) {
+    try {
+        const data = parseJsonPayload(payload);
+        if (data && typeof data === 'object') return data;
+    } catch (error) {
+        throw new Error(`Failed to parse status response: ${error.message}`);
+    }
+    return {};
+}
+
+function buildDeviceInfoRequest() {
+    return composeCommand(COMMANDS.DEVICE_INFO);
+}
+
+function parseDeviceInfoResponse(payload) {
+    try {
+        const data = parseJsonPayload(payload);
+        if (data && typeof data === 'object') return data;
+    } catch (error) {
+        throw new Error(`Failed to parse device info response: ${error.message}`);
+    }
+    return {};
+}
+
+module.exports = {
+    COMMANDS,
+    buildStatusRequest,
+    buildDeviceInfoRequest,
+    composeCommand,
+    parseFrame,
+    parseStatusResponse,
+    parseDeviceInfoResponse,
+};


### PR DESCRIPTION
## Summary
- add a new Marstek BLE battery driver with filtered discovery and pairing flow
- implement BLE protocol helper to compose hex commands with checksum and parse responses
- poll the BLE peripheral periodically to update the existing battery capabilities and read device info
- remove bundled Marstek BLE PNG assets so they can be provided manually later

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcdd662248832da6c49c015926fa4c