### PR TITLE
Add capability to expose last received message timestamp

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,7 +44,8 @@
         "measure_power_ongrid",
         "measure_power_offgrid",
         "measure_temperature",
-        "measure_battery"
+        "measure_battery",
+        "last_message_received"
       ],
       "energy": {
         "homeBattery": true,
@@ -185,6 +186,16 @@
       "setable": false,
       "decimals": 2,
       "uiComponent": "sensor"
+    },
+    "last_message_received": {
+      "type": "string",
+      "title": {
+        "en": "Last message received"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "insights": false
     }
   }
 }

--- a/drivers/marstek-venus/device.js
+++ b/drivers/marstek-venus/device.js
@@ -29,6 +29,7 @@ module.exports = class MarstekVenusDevice extends Homey.Device {
         if (!this.hasCapability('measure_power_ongrid')) await this.addCapability('measure_power_ongrid');
         if (!this.hasCapability('measure_power_offgrid')) await this.addCapability('measure_power_offgrid');
         if (!this.hasCapability('measure_power_pv')) await this.addCapability('measure_power_pv');
+        if (!this.hasCapability('last_message_received')) await this.addCapability('last_message_received');
 
         // Default capability values
         await this.setCapabilityValue('battery_charging_state', null);      // Charte state (Possible values: "idle", "charging", "discharging")
@@ -42,6 +43,7 @@ module.exports = class MarstekVenusDevice extends Homey.Device {
         await this.setCapabilityValue('measure_power_ongrid', null);        // Current power usage of on-grid port (in W)
         await this.setCapabilityValue('measure_power_offgrid', null);       // Current power usage of off-grid port (in W)
         await this.setCapabilityValue('measure_power_pv', null);            // Current power usage of off-grid port (in W)
+        await this.setCapabilityValue('last_message_received', null);       // ISO timestamp of the last received message
     }
 
     // Create an handler that we can use to bind/unbind the onMessage function
@@ -132,6 +134,8 @@ module.exports = class MarstekVenusDevice extends Homey.Device {
                 if (!isNaN(result.offgrid_power)) await this.setCapabilityValue('measure_power_offgrid', result.offgrid_power * -1);
                 if (!isNaN(result.pv_power)) await this.setCapabilityValue('measure_power_pv', result.pv_power * -1);
             }
+
+            await this.setCapabilityValue('last_message_received', new Date().toISOString());
 
         }
         catch (error) {


### PR DESCRIPTION
## Summary
- add a `last_message_received` capability so Homey can display the timestamp of the most recent Marstek message
- update the device logic to initialize the capability and refresh it whenever a valid UDP payload is processed

## Testing
- `npm run lint` *(fails: Parsing error: Cannot read file '/workspace/homey-marstek-connector/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_68dce8969920832d8f847170c400a34c