### PR TITLE
Improve Marstek Venus polling robustness

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,4 +1,7 @@
 ﻿{
+  "0.8.9": {
+    "en": "UDP broadcast or sending individual UDP packages to individual batteries is now configurable (defaults to broadcast)."
+  },
   "0.8.8": {
     "en": "UDP broadcast or sending individual UDP packages to individual batteries is now configurable (defaults to broadcast)."
   },

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.niewold.marstek",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "compatibility": ">=12.5.0",
   "sdk": 3,
   "brandColor": "#555555",

--- a/drivers/marstek-venus/device.ts
+++ b/drivers/marstek-venus/device.ts
@@ -104,9 +104,7 @@ export default class MarstekVenusDevice extends Homey.Device {
         if (this.debug) this.log('Start polling');
         this.myDriver.pollStart(this.getSetting('src'));
         // Also start updating the last received message capability
-        if (this.timeout) {
-            this.homey.clearInterval(this.timeout);
-        }
+        if (this.timeout) this.homey.clearInterval(this.timeout);
         this.timeout = this.homey.setInterval(async () => {
             if (this.timestamp) {
                 const now = new Date();

--- a/drivers/marstek-venus/device.ts
+++ b/drivers/marstek-venus/device.ts
@@ -104,6 +104,9 @@ export default class MarstekVenusDevice extends Homey.Device {
         if (this.debug) this.log('Start polling');
         this.myDriver.pollStart(this.getSetting('src'));
         // Also start updating the last received message capability
+        if (this.timeout) {
+            this.homey.clearInterval(this.timeout);
+        }
         this.timeout = this.homey.setInterval(async () => {
             if (this.timestamp) {
                 const now = new Date();
@@ -119,7 +122,10 @@ export default class MarstekVenusDevice extends Homey.Device {
     stopPolling() {
         if (this.debug) this.log('Stop polling');
         this.myDriver.pollStop(this.getSetting('src'));
-        if (this.timeout) this.homey.clearInterval(this.timeout);
+        if (this.timeout) {
+            this.homey.clearInterval(this.timeout);
+            this.timeout = undefined;
+        }
     }
 
     /**

--- a/drivers/marstek-venus/driver.ts
+++ b/drivers/marstek-venus/driver.ts
@@ -190,15 +190,15 @@ export default class MarstekVenusDriver extends Homey.Driver {
      * @param {string} device - Unique identifier of the device to poll.
      */
     pollStart(device: string) {
-        if (!device) {
-            this.error('pollStart called without a device identifier');
-            return;
-        }
+        if (!device) return this.error('pollStart called without a device identifier');
 
+        // Add device if not already added
         if (!this.pollDevices.includes(device)) {
             this.pollDevices.push(device);
+        } else {
+            if (this.debug) this.log('Device already in pollDevices array', device);
         }
-
+        // Start the main polling meganism, if not already (one interval per driver, many devices)
         if (!this.pollTimeout) {
             const interval = this.getPollInterval();
             if (this.debug) this.log('Started background polling with interval', interval);
@@ -558,7 +558,7 @@ export default class MarstekVenusDriver extends Homey.Driver {
             // Handler for messages received
             const handler = (json: any, remote: dgram.RemoteInfo) => {
                 // Always log received data during detection
-                if (this.debug) this.log(`Received for ${json.src}:`, JSON.stringify(json), JSON.stringify(remote));
+                if (this.debug) this.log(`Received for ${json?.src}:`, JSON.stringify(json), JSON.stringify(remote));
                 // Only further check messages that have the correct properties
                 if (json && json.src && json.result && json.result.device) {
                     // Detect if device is alread in array


### PR DESCRIPTION
## Summary
- prevent duplicate polling registrations and guard against missing device identifiers when starting or stopping Marstek Venus polling
- ensure poll intervals respect configured defaults and keep polling loop error handling consistent when intervals are refreshed
- reset per-device heartbeat intervals when restarting polling to avoid duplicate timers

## Testing
- npm run lint *(fails: existing repository lint errors and TypeScript version warning)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dddc13688832d8c16cf8113967045)