### PR TITLE
Fix disconnection and missing IP fallback issues

### DIFF
--- a/drivers/marstek-venus/driver.ts
+++ b/drivers/marstek-venus/driver.ts
@@ -107,6 +107,10 @@ export default class MarstekVenusDriver extends Homey.Driver {
     // Identifiers of devices currently participating in polling.
     private pollDevices: Array<string> = [];
 
+    // Timestamp of the last broadcast sent as fallback for devices without a stored IP.
+    private lastMissingIpBroadcastMs: number = 0;
+    private static readonly MISSING_IP_BROADCAST_INTERVAL_MS = 30 * 1000;
+
     /**
      * Called when the driver is initialised.
      * Sets up flow listeners and logs driver startup.
@@ -197,6 +201,7 @@ export default class MarstekVenusDriver extends Homey.Driver {
                     // if not forced broadcast, send to each device individually (except when device configured for broadcast)
                     const devices = this.getDevices();
                     let alsoBroadcast: boolean = false;
+                    let missingIpDevice: boolean = false;
                     for (const device of devices) {
                         try {
                             const broadcastSetting: boolean = !!device.getSetting('broadcast');
@@ -213,8 +218,7 @@ export default class MarstekVenusDriver extends Homey.Driver {
 
                                 const address = device.getStoreValue('address');
                                 if (!address) {
-                                    this.log('Device missing IP; falling back to broadcast.');
-                                    alsoBroadcast = true;
+                                    missingIpDevice = true;
                                     continue;
                                 }
 
@@ -226,6 +230,15 @@ export default class MarstekVenusDriver extends Homey.Driver {
                             }
                         } catch (err) {
                             this.error('Error sending to device:', err);
+                        }
+                    }
+                    // throttle missing-IP broadcast to at most once per interval
+                    if (missingIpDevice) {
+                        const now = Date.now();
+                        if (now - this.lastMissingIpBroadcastMs >= MarstekVenusDriver.MISSING_IP_BROADCAST_INTERVAL_MS) {
+                            this.log('Device missing IP; falling back to broadcast.');
+                            alsoBroadcast = true;
+                            this.lastMissingIpBroadcastMs = now;
                         }
                     }
                     // if at least one device is configured for broadcast, also send broadcast

--- a/drivers/marstek-venus/driver.ts
+++ b/drivers/marstek-venus/driver.ts
@@ -38,6 +38,15 @@ const factorDefaults: FactorDefaults = {
     VenusE: {
         0: {
         },
+        // firmware 153 uses the same new data format as 154
+        153: {
+            factor_bat_capacity: 1000,
+            factor_bat_power: 1,
+            factor_bat_temp: 1,
+            factor_total_grid_input_energy: 10,
+            factor_total_grid_output_energy: 10,
+            factor_total_load_energy: 10,
+        },
         154: {
             factor_bat_capacity: 1000,
             factor_bat_power: 1,
@@ -204,7 +213,8 @@ export default class MarstekVenusDriver extends Homey.Driver {
 
                                 const address = device.getStoreValue('address');
                                 if (!address) {
-                                    this.error('Device missing IP; next broadcast may fix this.');
+                                    this.log('Device missing IP; falling back to broadcast.');
+                                    alsoBroadcast = true;
                                     continue;
                                 }
 

--- a/lib/marstek-api.ts
+++ b/lib/marstek-api.ts
@@ -20,6 +20,8 @@ export default class MarstekSocket {
     private handlers: Array<Function> = [];
     private destroyed: boolean = false;
     private reconnectTimer?: NodeJS.Timeout;
+    private connectingPromise?: Promise<unknown>;
+    private closingIntentionally: boolean = false;
 
     /**
      * Creates a new MarstekSocket instance.
@@ -67,15 +69,13 @@ export default class MarstekSocket {
      * @returns {Promise<dgram.Socket>} Socket that is connected
      */
     async connect() {
-        // Return a promise structure
-        return new Promise((resolve, reject) => {
-            // If socket already exists, just resolve
-            if (this.socket && this.connected) {
-                this.log('Socket already exists, resolve without binding');
-                resolve(this.socket);
-                return;
-            }
+        if (this.socket && this.connected) {
+            this.log('Socket already exists, resolve without binding');
+            return this.socket;
+        }
+        if (this.connectingPromise) return this.connectingPromise;
 
+        this.connectingPromise = (new Promise((resolve, reject) => {
             // If socket not found, create and connect (bind)
             try {
                 this.log('Create and bind socket');
@@ -139,6 +139,10 @@ export default class MarstekSocket {
                 this.socket.on('close', () => {
                     this.error('onClose');
                     this.connected = false;
+                    if (this.closingIntentionally) {
+                        this.closingIntentionally = false;
+                        return;
+                    }
                     if (!this.destroyed) this.scheduleReconnect();
                 });
 
@@ -148,7 +152,11 @@ export default class MarstekSocket {
                 reject(err);
             }
 
+        })).finally(() => {
+            this.connectingPromise = undefined;
         });
+
+        return this.connectingPromise;
     }
 
     /**
@@ -300,22 +308,37 @@ export default class MarstekSocket {
         await Promise.all(tasks);
     }
 
+    private static readonly MAX_RECONNECT_ATTEMPTS = 5;
+    private static readonly RECONNECT_COOLDOWN_MS = 5 * 60 * 1000;
+
     /**
-     * Schedule a reconnect attempt after a delay, with exponential backoff up to 60 seconds.
-     * @param {number} delayMs Milliseconds to wait before reconnecting (default 5000)
+     * Schedule a reconnect attempt. Retries up to MAX_RECONNECT_ATTEMPTS times with
+     * exponential backoff, then waits RECONNECT_COOLDOWN_MS before starting over.
      */
-    private scheduleReconnect(delayMs: number = 5000) {
+    private scheduleReconnect(delayMs: number = 5000, attempt: number = 0) {
         if (this.reconnectTimer) return;
-        this.log('Scheduling socket reconnect in', delayMs, 'ms');
+
+        if (attempt >= MarstekSocket.MAX_RECONNECT_ATTEMPTS) {
+            const cooldownSec = MarstekSocket.RECONNECT_COOLDOWN_MS / 1000;
+            this.error(`Socket reconnect gave up after ${attempt} attempts; retrying in ${cooldownSec}s`);
+            this.reconnectTimer = setTimeout(() => {
+                this.reconnectTimer = undefined;
+                if (!this.destroyed) this.scheduleReconnect(5000, 0);
+            }, MarstekSocket.RECONNECT_COOLDOWN_MS);
+            return;
+        }
+
+        this.log(`Scheduling socket reconnect in ${delayMs}ms (attempt ${attempt + 1}/${MarstekSocket.MAX_RECONNECT_ATTEMPTS})`);
         this.reconnectTimer = setTimeout(() => {
             this.reconnectTimer = undefined;
             if (this.destroyed) return;
             this.log('Attempting socket reconnect...');
             this.connect().then(() => {
+                if (this.destroyed) { this.disconnect(); return; }
                 this.log('Socket reconnected successfully');
             }).catch((err) => {
                 this.error('Socket reconnect failed:', (err as Error).message || err);
-                if (!this.destroyed) this.scheduleReconnect(Math.min(delayMs * 2, 60000));
+                if (!this.destroyed) this.scheduleReconnect(Math.min(delayMs * 2, 60000), attempt + 1);
             });
         }, delayMs);
     }
@@ -325,6 +348,7 @@ export default class MarstekSocket {
      */
     disconnect() {
         if (this.socket) {
+            this.closingIntentionally = true;
             this.socket.close();
             this.socket = undefined;
         }

--- a/lib/marstek-api.ts
+++ b/lib/marstek-api.ts
@@ -18,6 +18,8 @@ export default class MarstekSocket {
     private connected: boolean = false;
     private socket?: dgram.Socket;
     private handlers: Array<Function> = [];
+    private destroyed: boolean = false;
+    private reconnectTimer?: NodeJS.Timeout;
 
     /**
      * Creates a new MarstekSocket instance.
@@ -130,12 +132,14 @@ export default class MarstekSocket {
                     this.error('onError', err);
                     this.disconnect();
                     this.connected = false;
+                    if (!this.destroyed) this.scheduleReconnect();
                 });
 
                 // Handle close events
                 this.socket.on('close', () => {
                     this.error('onClose');
                     this.connected = false;
+                    if (!this.destroyed) this.scheduleReconnect();
                 });
 
             } catch (err) {
@@ -297,6 +301,26 @@ export default class MarstekSocket {
     }
 
     /**
+     * Schedule a reconnect attempt after a delay, with exponential backoff up to 60 seconds.
+     * @param {number} delayMs Milliseconds to wait before reconnecting (default 5000)
+     */
+    private scheduleReconnect(delayMs: number = 5000) {
+        if (this.reconnectTimer) return;
+        this.log('Scheduling socket reconnect in', delayMs, 'ms');
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = undefined;
+            if (this.destroyed) return;
+            this.log('Attempting socket reconnect...');
+            this.connect().then(() => {
+                this.log('Socket reconnected successfully');
+            }).catch((err) => {
+                this.error('Socket reconnect failed:', (err as Error).message || err);
+                if (!this.destroyed) this.scheduleReconnect(Math.min(delayMs * 2, 60000));
+            });
+        }, delayMs);
+    }
+
+    /**
      * Disconnect the dgram UDP socket and destroy the instance
      */
     disconnect() {
@@ -312,6 +336,11 @@ export default class MarstekSocket {
      * Makes sure to disconnect and clear handler references.
      */
     destroy() {
+        this.destroyed = true;
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = undefined;
+        }
         this.disconnect();
         this.handlers = [];
     }


### PR DESCRIPTION
## Summary

- **Auto-reconnect UDP socket** after error/close with exponential backoff (5s → 60s max), so the app recovers without requiring a restart
- **Fall back to broadcast** when a device has no stored IP address instead of silently skipping it
- **Add VenusE firmware 153** to the factor table — uses the same data format as firmware 154

## Changes

- `lib/marstek-api.ts` — added `scheduleReconnect()` with exponential backoff; set `destroyed` flag on cleanup to prevent reconnect loops
- `drivers/marstek-venus/driver.ts` — firmware 153 factor defaults added; missing-IP branch now sets `alsoBroadcast = true` instead of continuing silently